### PR TITLE
Fix : Add styles to fix checkbox

### DIFF
--- a/components/SearchSandbox/styles.js
+++ b/components/SearchSandbox/styles.js
@@ -94,6 +94,13 @@ const componentStyles = css`
 	label {
 		font-weight: normal;
 	}
+	/* To fix the checkbox overlap in MulitList Cards */
+	ul li > label > span {
+		width: 80%;
+		text-overflow: ellipsis;
+		overflow: hidden;
+		white-space: nowrap;
+	}
 `;
 
 const fieldBadge = css`


### PR DESCRIPTION
Checkbox styles is not proper when there is long text.

Before : 
<img width="278" alt="screen shot 2018-10-15 at 5 58 47 pm" src="https://user-images.githubusercontent.com/22376783/46951032-5a1f1300-d0a4-11e8-9fcf-760f2cf3f2ed.png">
Now:
<img width="286" alt="screen shot 2018-10-15 at 5 58 25 pm" src="https://user-images.githubusercontent.com/22376783/46951041-60ad8a80-d0a4-11e8-899b-b7e1ce6fa64c.png">
