### PR TITLE
Refactor: Code Cleanup ♻️ 

### DIFF
--- a/components/SearchSandbox/components/DeleteJSON.js
+++ b/components/SearchSandbox/components/DeleteJSON.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Popconfirm, Button, notification } from 'antd';
+
+class DeleteJSON extends React.Component {
+	handleDeleteJSON = (id) => {
+		let responseMessage = {
+			message: 'Delete JSON',
+			description: 'You have successfully deleted JSON.',
+			duration: 4,
+		};
+		const { mappingsType, appbaseRef, setRenderKey } = this.props;
+		appbaseRef
+			.delete({
+				type: mappingsType,
+				id,
+			})
+			.then((res) => {
+				setRenderKey(res._timestamp);
+				notification.open(responseMessage);
+			})
+			.catch(() => {
+				responseMessage = {
+					message: 'Delete JSON',
+					description: 'There were error in Deleting JSON. Try again Later.',
+					duration: 2,
+				};
+				notification.open(responseMessage);
+			});
+	};
+
+	render() {
+		const { res } = this.props;
+		return (
+			<Popconfirm
+				title="Are you sure you want to delete this JSON?"
+				placement="bottomRight"
+				onConfirm={() => this.handleDeleteJSON(res._id)}
+				okText="Yes"
+			>
+				<Button shape="circle" icon="delete" style={{ marginRight: '5px' }} />
+			</Popconfirm>
+		);
+	}
+}
+
+export default DeleteJSON;

--- a/components/SearchSandbox/components/EditorJSON.js
+++ b/components/SearchSandbox/components/EditorJSON.js
@@ -1,0 +1,190 @@
+import React from 'react';
+import {
+ Button, Popover, Row, Col, Tooltip, notification,
+} from 'antd';
+
+import Ace from '../containers/AceEditor';
+
+class EditorJSON extends React.Component {
+	state = {
+		editorValue: '',
+		isValidJSON: true,
+		editorObjectId: '',
+		isEditable: false,
+	};
+
+	handleInitialEditorValue = (res) => {
+		const { _id: id, _index: del, ...objectJSON } = res;
+
+		const stringifiedJSON = JSON.stringify(objectJSON, null, '\t');
+
+		this.setState({
+			editorObjectId: id,
+			editorValue: stringifiedJSON,
+		});
+	};
+
+	resetEditorValues = () => {
+		this.setState({
+			editorObjectId: '',
+			editorValue: '',
+			isEditable: false,
+		});
+	};
+
+	handleUpdateJSON = (updatedJSONString) => {
+		const updatedJSON = JSON.parse(updatedJSONString);
+		const { mappingsType, appbaseRef, setRenderKey } = this.props;
+		const { editorObjectId } = this.state;
+		let responseMessage = {
+			message: 'Edit successfully saved',
+			description: 'The desired result data was successfully updated.',
+			duration: 4,
+		};
+		appbaseRef
+			.update({
+				type: mappingsType,
+				id: editorObjectId,
+				body: {
+					doc: updatedJSON,
+				},
+			})
+			.then((res) => {
+				this.setState({
+					isEditable: false,
+				});
+				setRenderKey(res._timestamp);
+				notification.open(responseMessage);
+			})
+			.catch(() => {
+				responseMessage = {
+					message: 'Update JSON',
+					description: 'There were error in Updating JSON. Try again Later.',
+					duration: 2,
+				};
+				notification.open(responseMessage);
+			});
+	};
+
+	copyJSON = (code) => {
+		const el = document.createElement('textarea');
+		el.value = JSON.stringify(code);
+		document.body.appendChild(el);
+		el.select();
+		document.execCommand('copy');
+		document.body.removeChild(el);
+		this.setState(
+			{
+				copied: true,
+			},
+			() => setTimeout(
+					() => this.setState({
+							copied: false,
+						}),
+					300,
+				),
+		);
+	};
+
+	handleEditing = () => {
+		this.setState(({ isEditable }) => ({
+			isEditable: !isEditable,
+		}));
+	};
+
+	handleEditingJSON = (value) => {
+		let isValidJSON = true;
+		try {
+			JSON.parse(value);
+		} catch (e) {
+			isValidJSON = false;
+		}
+		this.setState({
+			editorValue: value,
+			isValidJSON,
+		});
+	};
+
+	render() {
+		const {
+            isEditable, copied, isValidJSON, editorValue,
+        } = this.state; // prettier-ignore
+		const { res } = this.props;
+		return (
+			<Popover
+				placement="leftTop"
+				trigger="click"
+				onVisibleChange={
+                    visible => (visible ? this.handleInitialEditorValue(res) : this.resetEditorValues())
+				} // prettier-ignore
+				content={
+					isEditable ? (
+						<Ace
+							mode="json"
+							value={editorValue}
+							onChange={value => this.handleEditingJSON(value)}
+							theme="monokai"
+							name="editor-JSON"
+							fontSize={14}
+							showPrintMargin
+							style={{ maxHeight: '250px' }}
+							showGutter
+							highlightActiveLine
+							setOptions={{
+								showLineNumbers: true,
+								tabSize: 2,
+							}}
+							editorProps={{ $blockScrolling: true }}
+						/>
+					) : (
+						<pre style={{ width: 300 }}>{JSON.stringify(res, null, 4)}</pre>
+					)
+				}
+				title={(
+                    <Row>
+						<Col span={isEditable ? 19 : 18}>
+							<h5 style={{ display: 'inline-block' }}>
+								{isEditable ? 'Edit JSON' : 'JSON Result'}
+							</h5>
+						</Col>
+						<Col span={isEditable ? 5 : 6}>
+							<Tooltip visible={copied} title="Copied">
+								<Button
+									shape="circle"
+									icon="copy"
+									size="small"
+									onClick={() => this.copyJSON(res)}
+								/>
+							</Tooltip>
+							{isEditable ? (
+								<Button
+									size="small"
+									type="primary"
+									style={{ marginLeft: '5px' }}
+									disabled={!isValidJSON}
+									onClick={() => this.handleUpdateJSON(editorValue)}
+								>
+									Update
+								</Button>
+							) : (
+								<Button
+									size="small"
+									type="primary"
+									style={{ marginLeft: '5px' }}
+									disabled={!isValidJSON}
+									onClick={() => this.handleEditing()}
+								>
+									Edit
+								</Button>
+							)}
+						</Col>
+                    </Row>
+                )} // prettier-ignore
+			>
+				<Button shape="circle" icon="file-text" style={{ marginRight: '5px' }} />
+			</Popover>
+		);
+	}
+}
+
+export default EditorJSON;

--- a/components/SearchSandbox/components/RSWrapper.js
+++ b/components/SearchSandbox/components/RSWrapper.js
@@ -447,7 +447,7 @@ class RSComponentRender extends Component {
 	renderFormItem = (item, name) => {
 		const { componentProps } = this.props;
 		let FormInput = null;
-		const value = componentProps[name] !== undefined ? componentProps[name] : item.default;
+		const value = componentProps[name] === undefined ? item.default : componentProps[name];
 
 		switch (item.input) {
 			case 'bool': {

--- a/components/SearchSandbox/components/RSWrapper.js
+++ b/components/SearchSandbox/components/RSWrapper.js
@@ -19,21 +19,19 @@ import {
  DataSearch, MultiList, ReactiveList, CategorySearch,
 } from '@appbaseio/reactivesearch';
 
-import getNestedValue from '../utils';
 import dataSearchTypes from '../utils/datasearch-types';
 import multiListTypes from '../utils/multilist-types';
 import reactiveListTypes from '../utils/reactivelist-types';
 import categorySearchTypes from '../utils/categorysearch-types';
-import { generateDataField, generateFieldWeights } from '../utils/dataField';
+import { generateDataField } from '../utils/dataField';
 import constants from '../utils/constants';
 import { getComponentCode } from '../template';
 import PreviewList from './PreviewList';
+import { SandboxContext } from '../index';
+import getComponentProps from '../utils/getComponentProps'
 
 import {
-	deleteStyles,
-	rowStyles,
-	formWrapper,
-	componentStyles,
+ deleteStyles, rowStyles, formWrapper, componentStyles,
 } from '../styles';
 
 const componentMap = {
@@ -50,7 +48,13 @@ const propsMap = {
 	CategorySearch: categorySearchTypes,
 };
 
-export default class RSWrapper extends Component {
+const RSWrapper = props => (
+	<SandboxContext.Consumer>
+		{contextValue => <RSComponentRender {...contextValue} {...props} />}
+	</SandboxContext.Consumer>
+);
+
+class RSComponentRender extends Component {
 	constructor(props) {
 		super(props);
 
@@ -112,7 +116,9 @@ export default class RSWrapper extends Component {
 
 	getCategoryField = () => {
 		const { component, mappings } = this.props;
-		const { categoryField: { types } } = propsMap[component];
+		const {
+			categoryField: { types },
+		} = propsMap[component];
 
 		const fields = Object.keys(mappings).filter((field) => {
 			let fieldsToCheck = [mappings[field]];
@@ -128,7 +134,7 @@ export default class RSWrapper extends Component {
 		});
 
 		return fields;
-	}
+	};
 
 	setError = (error) => {
 		this.setState(
@@ -187,7 +193,7 @@ export default class RSWrapper extends Component {
 	};
 
 	handleSwitchPropChange = (name, value) => {
-	const { componentProps } = this.state;
+		const { componentProps } = this.state;
 		this.setState({
 			componentProps: {
 				...componentProps,
@@ -211,7 +217,7 @@ export default class RSWrapper extends Component {
 		this.setState({
 			isInputActive: false,
 		});
-	}
+	};
 
 	handleDropdownChange = (e, name) => {
 		const { componentProps } = this.state;
@@ -226,12 +232,14 @@ export default class RSWrapper extends Component {
 	};
 
 	handleDropdownSearch = (e) => {
-		const { target: { name, value } } = e;
+		const {
+			target: { name, value },
+		} = e;
 		this.setState({
 			isInputActive: true,
 			[name]: value,
 		});
-	}
+	};
 
 	handleSearchDataFieldChange = (item) => {
 		const field = item.key;
@@ -250,13 +258,11 @@ export default class RSWrapper extends Component {
 	};
 
 	handleSearchDataFieldDelete = (deleteIndex) => {
-	const { componentProps } = this.state;
+		const { componentProps } = this.state;
 		this.setState({
 			componentProps: {
 				...componentProps,
-				dataField: componentProps.dataField.filter(
-					(i, index) => index !== deleteIndex,
-				),
+				dataField: componentProps.dataField.filter((i, index) => index !== deleteIndex),
 				fieldWeights: componentProps.fieldWeights.filter(
 					(i, index) => index !== deleteIndex,
 				),
@@ -279,7 +285,7 @@ export default class RSWrapper extends Component {
 	};
 
 	handleSearchWeightChange = (index, value) => {
-	const { componentProps } = this.state;
+		const { componentProps } = this.state;
 		const fieldWeights = Object.assign([], componentProps.fieldWeights, {
 			[index]: value,
 		});
@@ -292,7 +298,7 @@ export default class RSWrapper extends Component {
 	};
 
 	handleAddFieldRow = () => {
-	const { componentProps } = this.state;
+		const { componentProps } = this.state;
 		const field = this.getAvailableDataField().find(
 			item => !componentProps.dataField.includes(item),
 		);
@@ -328,7 +334,7 @@ export default class RSWrapper extends Component {
 	renderComponentCode = () => {
 		const {
 			component, id, mappings, componentProps, customProps,
-		} = this.props;
+		} = this.props; // prettier-ignore
 		const customComponentProps = customProps[component];
 
 		const config = {
@@ -439,11 +445,9 @@ export default class RSWrapper extends Component {
 	};
 
 	renderFormItem = (item, name) => {
-	const { componentProps, mappings } = this.props;
+		const { componentProps } = this.props;
 		let FormInput = null;
-		const value = componentProps[name] !== undefined
-				? componentProps[name]
-				: item.default;
+		const value = componentProps[name] !== undefined ? componentProps[name] : item.default;
 
 		switch (item.input) {
 			case 'bool': {
@@ -475,16 +479,26 @@ export default class RSWrapper extends Component {
 
 				const {
 					onPropChange, id, component, mappingsURL,
-				} = this.props;
-				const { componentProps: stateComponentProps, isInputActive, searchTerm } = this.state;
+				} = this.props; // prettier-ignore
+				const {
+					componentProps: stateComponentProps,
+					isInputActive,
+					searchTerm,
+				} = this.state;
 
 				if (name === 'categoryField') {
-					noOptionsMessage = <p style={{ lineHeight: '1.5' }}>There are no compatible fields present in your data mappings. <a href={mappingsURL}>You can edit your mappings</a> (agggregation components)</p>;
+					noOptionsMessage = (
+						<p style={{ lineHeight: '1.5' }}>
+							There are no compatible fields present in your data mappings.{' '}
+							<a href={mappingsURL}>You can edit your mappings</a> (agggregation
+							components)
+						</p>
+					);
 
 					this.getCategoryField().forEach(field => dropdownOptions.push({
-						label: field,
-						key: field,
-					}));
+							label: field,
+							key: field,
+						}));
 
 					if (dropdownOptions.length) {
 						if (!stateComponentProps.categoryField) {
@@ -493,24 +507,25 @@ export default class RSWrapper extends Component {
 							});
 						}
 
-						selectedDropdown = dropdownOptions
-							.find(option => option.key === stateComponentProps[name]);
+						selectedDropdown = dropdownOptions.find(
+							option => option.key === stateComponentProps[name],
+						);
 						selectedValue = selectedDropdown
-						? selectedDropdown.label
-						: dropdownOptions[0].label;
+							? selectedDropdown.label
+							: dropdownOptions[0].label;
 					}
 				} else {
 					dropdownOptions = propsMap[component][name].options;
-					selectedDropdown = dropdownOptions
-						.find(option => option.key === stateComponentProps[name]);
+					selectedDropdown = dropdownOptions.find(
+						option => option.key === stateComponentProps[name],
+					);
 					selectedValue = selectedDropdown
 						? selectedDropdown.label
 						: propsMap[component][name].default;
 				}
 
 				if (isInputActive) {
-					dropdownOptions = dropdownOptions
-						.filter(option => option.label.toLowerCase().includes(searchTerm.toLowerCase()));
+					dropdownOptions = dropdownOptions.filter(option => option.label.toLowerCase().includes(searchTerm.toLowerCase()));
 				}
 
 				if (!dropdownOptions.length) {
@@ -543,7 +558,9 @@ export default class RSWrapper extends Component {
 							onChange={this.handleDropdownSearch}
 						/>
 					</Dropdown>
-				) : noOptionsMessage;
+				) : (
+					noOptionsMessage
+				);
 				break;
 			}
 
@@ -627,86 +644,35 @@ export default class RSWrapper extends Component {
 
 	render() {
 		const {
-			componentProps, component, id, mappings, customProps, full, showDelete, onDelete, showCodePreview, showCustomList
+			componentProps,
+			component,
+			id,
+			mappings,
+			customProps,
+			full,
+			showDelete,
+			onDelete,
+			showCodePreview,
+			showCustomList,
+			setRenderKey,
 		} = this.props;
 		const { showModal, componentProps: stateComponentProps, previewModal } = this.state;
 		if (!componentProps.dataField) return null;
+
 		const RSComponent = componentMap[component];
 		let tutorialClass = '';
 		let editTutorialClass = '';
-		let otherProps = {};
+
 		if (id === 'search') {
 			tutorialClass = 'search-tutorial-1';
 			editTutorialClass = 'search-tutorial-2';
-			otherProps = {
-				fieldWeights: generateFieldWeights(
-					componentProps.dataField,
-					componentProps.fieldWeights,
-					mappings,
-				),
-				highlightField: componentProps.dataField,
-			};
 		}
 		if (id === 'result') {
 			tutorialClass = 'search-tutorial-4';
 			editTutorialClass = 'search-tutorial-5';
 		}
-		if (component === 'CategorySearch') {
-			otherProps = {
-				categoryField: generateDataField(
-					'MultiList',
-					componentProps.categoryField,
-					mappings,
-				),
-				fieldWeights: generateFieldWeights(
-					componentProps.dataField,
-					componentProps.fieldWeights,
-					mappings,
-				),
-				highlightField: componentProps.dataField,
-			};
-		}
-		const { componentProps: { metaFields, ...restProps } } = this.props;
-		const isMetaDataPresent = metaFields && metaFields.title && metaFields.description;
 
-		if (id === 'result' && isMetaDataPresent) {
-			const {
-				url: urlKey, title: titleKey, image: imageKey, description: descriptionKey,
-			} = metaFields;
-			otherProps = {
-					onData: (res) => {
-						const url = getNestedValue(res, urlKey);
-						const title = getNestedValue(res, titleKey);
-						const description = getNestedValue(res, descriptionKey);
-						const image = getNestedValue(res, imageKey);
-						const { renderJSONEditor, renderDeleteJSON } = this.props;
-
-						return (
-						<Row type="flex" key={res._id} style={{ margin: '20px auto', borderBottom: '1px solid #ededed' }}>
-							<Col span={image ? 6 : 0}>
-								<img style={{ width: '100%' }} src={image} alt={title} />
-							</Col>
-							<Col span={image ? 18 : 24}>
-								<h3 style={{ fontWeight: '600' }} dangerouslySetInnerHTML={{__html: title}} />
-								<p style={{ fontSize: '1em' }} dangerouslySetInnerHTML={{ __html: description }} />
-							</Col>
-							<div style={{ width: '100%', marginBottom: '10px', textAlign: 'right' }}>
-								{url ? <Button shape="circle" icon="link" style={{ marginRight: '5px' }} onClick={() => window.open(url, '_blank')} />
-								: null}
-								{renderJSONEditor(res)}
-								{renderDeleteJSON(res)}
-							</div>
-						</Row>
-					);
-				},
-			};
-		}
-
-		if (id === 'result' && componentProps.sortBy === 'best') {
-			delete restProps.sortBy;
-		}
-
-		const showPreview =	component === 'ReactiveList';
+		const showPreview = component === 'ReactiveList';
 		const customComponentProps = customProps[component];
 
 		return (
@@ -746,16 +712,10 @@ export default class RSWrapper extends Component {
 					<Col span={full ? 24 : 20} id={id} className={tutorialClass}>
 						<RSComponent
 							componentId={id}
-							{...restProps}
-							dataField={generateDataField(
-								component,
-								componentProps.dataField,
-								mappings,
-							)}
 							className={componentStyles}
-							fuzziness={componentProps.fuzziness || 0}
-							size={parseInt(componentProps.size || 10, 10)}
-							{...otherProps}
+							{...getComponentProps({
+								component, componentProps, mappings, setRenderKey,
+							})}
 							{...customComponentProps}
 						/>
 					</Col>
@@ -789,15 +749,10 @@ export default class RSWrapper extends Component {
 						options={Object.keys(mappings)}
 						componentProps={stateComponentProps}
 						componentId={id}
-						getNestedValue={getNestedValue}
 						handlePreviewModal={this.handlePreviewModal}
 						handleSavePreview={this.handleSavePreview}
 						visible={previewModal}
-						dataField={generateDataField(
-							component,
-							componentProps.dataField,
-							mappings,
-						)}
+						dataField={generateDataField(component, componentProps.dataField, mappings)}
 					/>
 				) : null}
 			</div>
@@ -808,3 +763,5 @@ export default class RSWrapper extends Component {
 RSWrapper.defaultProps = {
 	showDelete: true,
 };
+
+export default RSWrapper;

--- a/components/SearchSandbox/components/RenderResults.js
+++ b/components/SearchSandbox/components/RenderResults.js
@@ -1,0 +1,158 @@
+import React from 'react';
+import {
+ Tree, Row, Col, Button,
+} from 'antd';
+import Appbase from 'appbase-js';
+import ExpandCollapse from 'react-expand-collapse';
+
+import EditorJSON from './EditorJSON';
+import DeleteJSON from './DeleteJSON';
+import { listItem } from '../styles';
+import { SandboxContext } from '../index';
+import getNestedValue from '../utils';
+
+const { TreeNode } = Tree;
+
+const RenderResults = props => (
+	<SandboxContext.Consumer>
+		{contextValue => <RenderResultsConsumer {...contextValue} {...props} />}
+	</SandboxContext.Consumer>
+);
+
+class RenderResultsConsumer extends React.Component {
+	constructor(props) {
+		super(props);
+		const { appName, url, credentials } = props;
+		this.appbaseRef = Appbase({
+			app: appName,
+			url,
+			credentials,
+		});
+	}
+
+	renderAsTree = (res, key = '0') => {
+		if (!res) return null;
+		const iterable = Array.isArray(res) ? res : Object.keys(res);
+		return iterable.map((item, index) => {
+			const type = typeof res[item];
+			if (type === 'string' || type === 'number') {
+				const title = (
+					<div>
+						<span>{item}:</span>
+						&nbsp;
+						<span dangerouslySetInnerHTML={{ __html: res[item] }} />
+					</div>
+				);
+				return <TreeNode title={title} key={`${key}-${index + 1}`} />;
+			}
+			const hasObject = res[item] === undefined && typeof item !== 'string';
+			const node = hasObject ? item : res[item];
+			return (
+				<TreeNode
+					title={
+						typeof item !== 'string'
+							? 'Object'
+							: `${node || Array.isArray(res) ? item : `${item}: null`}`
+					}
+					key={`${key}-${index + 1}`}
+				>
+					{this.renderAsTree(node, `${key}-${index + 1}`)}
+				</TreeNode>
+			);
+		});
+	};
+
+	render() {
+		const {
+			res,
+			setRenderKey,
+			mappingsType,
+			triggerClickAnalytics,
+			type,
+			metaFields,
+		} = this.props;
+		const { _id, _index, ...renderedJSON } = res;
+		switch (type) {
+			case 'list': {
+				const {
+					url: urlKey,
+					title: titleKey,
+					image: imageKey,
+					description: descriptionKey,
+				} = metaFields;
+				const url = getNestedValue(res, urlKey);
+				const title = getNestedValue(res, titleKey);
+				const description = getNestedValue(res, descriptionKey);
+				const image = getNestedValue(res, imageKey);
+				return (
+					<Row
+						type="flex"
+						onClick={triggerClickAnalytics}
+						key={res._id}
+						style={{ margin: '20px auto', borderBottom: '1px solid #ededed' }}
+					>
+						<Col span={image ? 6 : 0}>
+							<img style={{ width: '100%' }} src={image} alt={title} />
+						</Col>
+						<Col span={image ? 18 : 24}>
+							<h3
+								style={{ fontWeight: '600' }}
+								dangerouslySetInnerHTML={{ __html: title }}
+							/>
+							<p
+								style={{ fontSize: '1em' }}
+								dangerouslySetInnerHTML={{ __html: description }}
+							/>
+						</Col>
+						<div style={{ width: '100%', marginBottom: '10px', textAlign: 'right' }}>
+							{url ? (
+								<Button
+									shape="circle"
+									icon="link"
+									style={{ marginRight: '5px' }}
+									onClick={() => window.open(url, '_blank')}
+								/>
+							) : null}
+							<EditorJSON
+								res={res}
+								mappingsType={mappingsType}
+								appbaseRef={this.appbaseRef}
+								setRenderKey={setRenderKey}
+							/>
+							<DeleteJSON
+								res={res}
+								mappingsType={mappingsType}
+								appbaseRef={this.appbaseRef}
+								setRenderKey={setRenderKey}
+							/>
+						</div>
+					</Row>
+				);
+			}
+			default:
+				return (
+					<div className={listItem} key={_id} onClick={triggerClickAnalytics}>
+						<ExpandCollapse previewHeight="390px" expandText="Show more">
+							{<Tree showLine>{this.renderAsTree(renderedJSON)}</Tree>}
+						</ExpandCollapse>
+						<div style={{ marginTop: 10, textAlign: 'right' }}>
+							<EditorJSON
+								res={res}
+								mappingsType={mappingsType}
+								appbaseRef={this.appbaseRef}
+								setRenderKey={setRenderKey}
+							/>
+							<DeleteJSON
+								res={res}
+								mappingsType={mappingsType}
+								appbaseRef={this.appbaseRef}
+								setRenderKey={setRenderKey}
+							/>
+						</div>
+					</div>
+				);
+		}
+	}
+}
+
+export default RenderResults;

--- a/components/SearchSandbox/containers/Editor.js
+++ b/components/SearchSandbox/containers/Editor.js
@@ -11,25 +11,14 @@ import {
 	Dropdown,
 	Icon,
 	Menu,
-	Tree,
-	Popover,
-	Tooltip,
-	notification,
-	Popconfirm,
 	message,
 } from 'antd';
 import { ReactiveBase, SelectedFilters } from '@appbaseio/reactivesearch';
-import ExpandCollapse from 'react-expand-collapse';
 import PropTypes from 'prop-types';
 
-import Appbase from 'appbase-js';
-
-import Ace from './AceEditor';
 import multiListTypes from '../utils/multilist-types';
 import RSWrapper from '../components/RSWrapper';
-import { listItem, formWrapper } from '../styles';
-
-const { TreeNode } = Tree;
+import { formWrapper } from '../styles';
 
 export default class Editor extends Component {
 	constructor(props) {
@@ -41,19 +30,9 @@ export default class Editor extends Component {
 			listComponentProps: {
 				dataField: dataFields.length ? dataFields[0] : '',
 			},
-			editorValue: '',
-			isValidJSON: true,
-			editorObjectId: '',
 			renderKey: Date.now(),
 			showVideo: false,
-			isEditable: false,
 		};
-		const { appName, url, credentials } = props;
-		this.appbaseRef = Appbase({
-			app: appName,
-			url,
-			credentials,
-		});
 	}
 
 	getAvailableDataField = () => {
@@ -74,26 +53,6 @@ export default class Editor extends Component {
 		});
 
 		return fields;
-	};
-
-	copyJSON = (code) => {
-		const el = document.createElement('textarea');
-		el.value = JSON.stringify(code);
-		document.body.appendChild(el);
-		el.select();
-		document.execCommand('copy');
-		document.body.removeChild(el);
-		this.setState(
-			{
-				copied: true,
-			},
-			() => setTimeout(
-					() => this.setState({
-							copied: false,
-						}),
-					300,
-				),
-		);
 	};
 
 	showModal = () => {
@@ -180,106 +139,6 @@ export default class Editor extends Component {
 				...listComponentProps,
 				[name]: type === 'number' ? parseInt(value, 10) : value,
 			},
-		});
-	};
-
-	handleUpdateJSON = (updatedJSONString) => {
-		const updatedJSON = JSON.parse(updatedJSONString);
-		const { mappingsType } = this.props;
-		const { editorObjectId } = this.state;
-		let responseMessage = {
-			message: 'Edit successfully saved',
-			description: 'The desired result data was successfully updated.',
-			duration: 4,
-		};
-		this.appbaseRef
-			.update({
-				type: mappingsType,
-				id: editorObjectId,
-				body: {
-					doc: updatedJSON,
-				},
-			})
-			.then((res) => {
-				this.setState({
-					isEditable: false,
-					renderKey: res._timestamp, // eslint-disable-line
-				});
-				notification.open(responseMessage);
-			})
-			.catch(() => {
-				responseMessage = {
-					message: 'Update JSON',
-					description: 'There were error in Updating JSON. Try again Later.',
-					duration: 2,
-				};
-				notification.open(responseMessage);
-			});
-	};
-
-	handleDeleteJSON = (id) => {
-		let responseMessage = {
-			message: 'Delete JSON',
-			description: 'You have successfully deleted JSON.',
-			duration: 4,
-		};
-		const { mappingsType } = this.props;
-		this.appbaseRef
-			.delete({
-				type: mappingsType,
-				id,
-			})
-			.then((res) => {
-				this.setState({
-					renderKey: res._timestamp,
-				});
-				notification.open(responseMessage);
-			})
-			.catch(() => {
-				responseMessage = {
-					message: 'Delete JSON',
-					description: 'There were error in Deleting JSON. Try again Later.',
-					duration: 2,
-				};
-				notification.open(responseMessage);
-			});
-	};
-
-	handleEditing = () => {
-		this.setState(({ isEditable }) => ({
-			isEditable: !isEditable,
-		}));
-	};
-
-	handleEditingJSON = (value) => {
-		let isValidJSON = true;
-		try {
-			JSON.parse(value);
-		} catch (e) {
-			isValidJSON = false;
-		}
-		this.setState({
-			editorValue: value,
-			isValidJSON,
-		});
-	};
-
-	handleInitialEditorValue = (res) => {
-		const { _id: id, _index: del, ...objectJSON } = res;
-
-		const stringifiedJSON = JSON.stringify(objectJSON, null, '\t');
-
-		this.setState({
-			editorObjectId: id,
-			editorValue: stringifiedJSON,
-		});
-	};
-
-	resetEditorValues = () => {
-		this.setState({
-			editorObjectId: '',
-			editorValue: '',
-			isEditable: false,
 		});
 	};
 
@@ -383,128 +242,11 @@ export default class Editor extends Component {
 		);
 	};
 
-	renderAsTree = (res, key = '0') => {
-		if (!res) return null;
-		const iterable = Array.isArray(res) ? res : Object.keys(res);
-		return iterable.map((item, index) => {
-			const type = typeof res[item];
-			if (type === 'string' || type === 'number') {
-				const title = (
-					<div>
-						<span>{item}:</span>
-						&nbsp;
-						<span dangerouslySetInnerHTML={{ __html: res[item] }} />
-					</div>
-				);
-				return <TreeNode title={title} key={`${key}-${index + 1}`} />;
-			}
-			const hasObject = res[item] === undefined && typeof item !== 'string';
-			const node = hasObject ? item : res[item];
-			return (
-				<TreeNode
-					title={
-						typeof item !== 'string'
-							? 'Object'
-							: `${node || Array.isArray(res) ? item : `${item}: null`}`
-					}
-					key={`${key}-${index + 1}`}
-				>
-					{this.renderAsTree(node, `${key}-${index + 1}`)}
-				</TreeNode>
-			);
+	setRenderKey = (newKey) => {
+		this.setState({
+			renderKey: newKey,
 		});
-	};
-
-	renderDeleteJSON = res => (
-		<Popconfirm
-			title="Are you sure you want to delete this JSON?"
-			placement="bottomRight"
-			onConfirm={() => this.handleDeleteJSON(res._id)}
-			okText="Yes"
-		>
-			<Button shape="circle" icon="delete" style={{ marginRight: '5px' }} />
-		</Popconfirm>
-	);
-
-	renderJSONEditor = (res) => {
-		const {
-			isEditable, copied, isValidJSON, editorValue,
-		} = this.state;
-		return (
-			<Popover
-				placement="leftTop"
-				trigger="click"
-				onVisibleChange={visible => (
-					visible ? this.handleInitialEditorValue(res) : this.resetEditorValues())
-				}
-				content={
-					isEditable ? (
-						<Ace
-							mode="json"
-							value={editorValue}
-							onChange={value => this.handleEditingJSON(value)}
-							theme="monokai"
-							name="editor-JSON"
-							fontSize={14}
-							showPrintMargin
-							style={{ maxHeight: '250px' }}
-							showGutter
-							highlightActiveLine
-							setOptions={{
-								showLineNumbers: true,
-								tabSize: 2,
-							}}
-							editorProps={{ $blockScrolling: true }}
-						/>
-					) : (
-						<pre style={{ width: 300 }}>{JSON.stringify(res, null, 4)}</pre>
-					)
-				}
-				title={(
-					<Row>
-						<Col span={isEditable ? 19 : 18}>
-							<h5 style={{ display: 'inline-block' }}>
-								{isEditable ? 'Edit JSON' : 'JSON Result'}
-							</h5>
-						</Col>
-						<Col span={isEditable ? 5 : 6}>
-							<Tooltip visible={copied} title="Copied">
-								<Button
-									shape="circle"
-									icon="copy"
-									size="small"
-									onClick={() => this.copyJSON(res)}
-								/>
-							</Tooltip>
-							{isEditable ? (
-								<Button
-									size="small"
-									type="primary"
-									style={{ marginLeft: '5px' }}
-									disabled={!isValidJSON}
-									onClick={() => this.handleUpdateJSON(editorValue)}
-								>
-									Update
-								</Button>
-							) : (
-								<Button
-									size="small"
-									type="primary"
-									style={{ marginLeft: '5px' }}
-									disabled={!isValidJSON}
-									onClick={() => this.handleEditing()}
-								>
-									Edit
-								</Button>
-							)}
-						</Col>
-					</Row>
-				)}
-			>
-				<Button shape="circle" icon="file-text" style={{ marginRight: '5px' }} />
-			</Popover>
-		);
-	};
+	}
 
 	render() {
 		const {
@@ -512,41 +254,10 @@ export default class Editor extends Component {
 			appName,
 			credentials,
 			url,
-			mappings,
-			customProps,
-			onPropChange,
-			mappingsType,
-			showCodePreview,
-			showCustomList,
 		} = this.props;
 		const {
 			renderKey, showModal, showVideo,
 		} = this.state;
-		let resultComponentProps = componentProps.result || {};
-		resultComponentProps = {
-			size: 5,
-			pagination: true,
-			paginationAt: 'bottom',
-			scrollTarget: 'result',
-			...resultComponentProps,
-			onData: (res, triggerClickAnalytics) => {
-				const { _id, _index, ...renderedJSON } = res;
-				return (
-					<div className={listItem} key={res._id} onClick={triggerClickAnalytics}>
-						<ExpandCollapse previewHeight="390px" expandText="Show more">
-							{<Tree showLine>{this.renderAsTree(renderedJSON)}</Tree>}
-						</ExpandCollapse>
-						<div style={{ marginTop: 10, textAlign: 'right' }}>
-							{this.renderJSONEditor(res)}
-							{this.renderDeleteJSON(res)}
-						</div>
-					</div>
-				);
-			},
-			react: {
-				and: Object.keys(componentProps).filter(item => item !== 'result'),
-			},
-		};
 		const title = (
 			<span>
 				Search Preview{' '}
@@ -585,12 +296,7 @@ export default class Editor extends Component {
 									<RSWrapper
 										id={config}
 										component="MultiList"
-										mappings={mappings}
-										customProps={customProps}
-										showCodePreview={showCodePreview}
-										showCustomList={showCustomList}
 										componentProps={componentProps[config] || {}}
-										onPropChange={onPropChange}
 										onDelete={this.props.deleteComponent}
 										full
 									/>
@@ -604,12 +310,7 @@ export default class Editor extends Component {
 								component={
 									this.props.useCategorySearch ? 'CategorySearch' : 'DataSearch'
 								}
-								mappings={mappings}
-								customProps={customProps}
-								showCodePreview={showCodePreview}
-								showCustomList={showCustomList}
 								componentProps={componentProps.search || {}}
-								onPropChange={onPropChange}
 							/>
 						</Card>
 
@@ -619,15 +320,15 @@ export default class Editor extends Component {
 								id="result"
 								component="ReactiveList"
 								key={renderKey}
-								mappings={mappings}
-								customProps={customProps}
-								mappingsType={mappingsType}
-								showCodePreview={showCodePreview}
-								showCustomList={showCustomList}
-								componentProps={resultComponentProps}
-								renderJSONEditor={this.renderJSONEditor}
-								renderDeleteJSON={this.renderDeleteJSON}
-								onPropChange={onPropChange}
+								componentProps={
+									componentProps.result ? {
+											...componentProps.result,
+											react: {
+												and: Object.keys(componentProps).filter(item => item !== 'result'),
+											},
+										} : {}
+									}
+								setRenderKey={this.setRenderKey}
 								full
 								showDelete={false}
 							/>

--- a/components/SearchSandbox/utils/getComponentProps.js
+++ b/components/SearchSandbox/utils/getComponentProps.js
@@ -3,7 +3,7 @@ import React from 'react';
 import RenderResults from '../components/RenderResults';
 import { generateFieldWeights, generateDataField } from './dataField';
 
-function dataSearchProps({ componentProps, mappings }) {
+function getDataSearchProps({ componentProps, mappings }) {
 	return {
 		...componentProps,
 		dataField: generateDataField('DataSearch', componentProps.dataField, mappings),
@@ -16,7 +16,7 @@ function dataSearchProps({ componentProps, mappings }) {
 	};
 }
 
-function categorySearchProps({ componentProps, mappings }) {
+function getCategorySearchProps({ componentProps, mappings }) {
 	return {
 		...componentProps,
 		dataField: generateDataField('CategorySearch', componentProps.dataField, mappings),
@@ -30,7 +30,7 @@ function categorySearchProps({ componentProps, mappings }) {
 	};
 }
 
-function resultProps({ componentProps, setRenderKey, mappings }) {
+function getReactiveListProps({ componentProps, setRenderKey, mappings }) {
 	const { metaFields } = componentProps;
 	const isMetaDataPresent = metaFields && metaFields.title && metaFields.description;
 	if (componentProps.sortBy === 'best') {
@@ -62,11 +62,11 @@ export default function getComponentProps({
 }) {
 	switch (component) {
 		case 'DataSearch':
-			return dataSearchProps({ componentProps, mappings });
+			return getDataSearchProps({ componentProps, mappings });
 		case 'CategorySearch':
-			return categorySearchProps({ componentProps, mappings });
+			return getCategorySearchProps({ componentProps, mappings });
 		case 'ReactiveList':
-			return resultProps({
+			return getReactiveListProps({
 				componentProps,
 				setRenderKey,
 				mappings,

--- a/components/SearchSandbox/utils/getComponentProps.js
+++ b/components/SearchSandbox/utils/getComponentProps.js
@@ -1,0 +1,82 @@
+import React from 'react';
+
+import RenderResults from '../components/RenderResults';
+import { generateFieldWeights, generateDataField } from './dataField';
+
+function dataSearchProps({ componentProps, mappings }) {
+	return {
+		...componentProps,
+		dataField: generateDataField('DataSearch', componentProps.dataField, mappings),
+		fieldWeights: generateFieldWeights(
+			componentProps.dataField,
+			componentProps.fieldWeights,
+			mappings,
+		),
+		highlightField: componentProps.dataField,
+	};
+}
+
+function categorySearchProps({ componentProps, mappings }) {
+	return {
+		...componentProps,
+		dataField: generateDataField('CategorySearch', componentProps.dataField, mappings),
+		categoryField: generateDataField('MultiList', componentProps.categoryField, mappings),
+		fieldWeights: generateFieldWeights(
+			componentProps.dataField,
+			componentProps.fieldWeights,
+			mappings,
+		),
+		highlightField: componentProps.dataField,
+	};
+}
+
+function resultProps({ componentProps, setRenderKey, mappings }) {
+	const { metaFields } = componentProps;
+	const isMetaDataPresent = metaFields && metaFields.title && metaFields.description;
+	if (componentProps.sortBy === 'best') {
+		delete componentProps.sortBy;
+	}
+	return {
+		size: 5,
+		pagination: true,
+		paginationAt: 'bottom',
+		scrollTarget: 'result',
+		fuzziness: 0,
+		...componentProps,
+		dataField: generateDataField('ReactiveList', componentProps.dataField, mappings),
+		onData: (res, triggerAnalytics) => (
+			<RenderResults
+				key={res._id}
+				res={res}
+				type={isMetaDataPresent ? 'list' : 'tree'}
+				metaFields={metaFields}
+				setRenderKey={setRenderKey}
+				triggerAnalytics={triggerAnalytics}
+			/>
+		),
+	};
+}
+
+export default function getComponentProps({
+ component, componentProps, mappings, setRenderKey,
+}) {
+	switch (component) {
+		case 'DataSearch':
+			return dataSearchProps({ componentProps, mappings });
+		case 'CategorySearch':
+			return categorySearchProps({ componentProps, mappings });
+		case 'ReactiveList':
+			return resultProps({
+				componentProps,
+				setRenderKey,
+				mappings,
+			});
+		case 'MultiList':
+			return {
+				...componentProps,
+				dataField: generateDataField('MultiList', componentProps.dataField, mappings),
+			};
+		default:
+			return {};
+	}
+}


### PR DESCRIPTION
**Changes**
- Separate props logic from `Editor` & `RSWrapper` to a single file.
- Use consumer in RSWrapper instead of passing props from Editor.
- Separate Logic for ReactiveList `onData` - `RenderResults`
   - We can add different type to change the layout of ReactiveList now.
- Separate `JSON Editor` & `Delete JSON` to separate Component