### PR TITLE
chore: Upgrade Sentry version from 4 to 5 

### DIFF
--- a/components/shared/ErrorToaster/ErrorToaster.js
+++ b/components/shared/ErrorToaster/ErrorToaster.js
@@ -23,9 +23,7 @@ class ErrorToaster extends React.Component {
 	componentDidCatch(error, errorInfo) {
 		this.catchError();
 		Sentry.withScope((scope) => {
-			Object.keys(errorInfo).forEach((key) => {
-				scope.setExtra(key, errorInfo[key]);
-			});
+			scope.setExtras(errorInfo);
 			Sentry.captureException(error);
 		});
 	}


### PR DESCRIPTION
## Describe the change in this PR?
- This PR upgrades Sentry browser from `v4.x` to `v5.x`
- Notion Card: [Issue Link](https://www.notion.so/appbase/Sentry-Issues-Sep-2020-14bb21c7832a443f874363e07df559e0)

## How has this PR tested? Provide relevant screenshots
- Ran regression using Cypress
- Tested explicit errors and checked network request to validate Sentry integration


Dependent PR: https://github.com/appbaseio-confidential/arc-dashboard/pull/255
