### PR TITLE
fix: clear-all bug in analytics

### DIFF
--- a/modules/reducers/getSelectedFilters.js
+++ b/modules/reducers/getSelectedFilters.js
@@ -24,8 +24,10 @@ function getSelectedFilters(state = {}, action) {
 					[action.payload.filterId]: obj,
 				};
 			}
-			const { [action.payload.filterId]: del, ...obj } = state;
-			return obj;
+			return {
+				...state,
+				[action.payload.filterId]: {},
+			};
 		}
 		default:
 			return state;


### PR DESCRIPTION
updated the getSelectedFilters reducer for CLEAR_FILTER_VALUE, to update and return the state object with the value for filterId set to an empty object



https://www.loom.com/share/f48c6f46a7bb4a418d99db9aada6c0eb