### PR TITLE
fix: optimise initial rendering time in analytics overview

### DIFF
--- a/components/analytics/AdvancedAnalytics.js
+++ b/components/analytics/AdvancedAnalytics.js
@@ -1,0 +1,148 @@
+import React, { Fragment } from 'react';
+import { css } from 'react-emotion';
+import PropTypes from 'prop-types';
+import { getFilteredResults } from '../../utils/helpers';
+import { mediaKey } from '../../utils/media';
+import SearchVolumeChart from '../shared/Chart/SearchVolume';
+import Flex from '../shared/Flex';
+import Searches from './components/Searches';
+import { noResultsFull, popularFiltersCol, popularResultsCol, popularSearchesCol } from './utils';
+
+const results = css`
+	width: 100%;
+	margin-top: 20px;
+	${mediaKey.small} {
+		flex-direction: column;
+	}
+`;
+const searchCls = css`
+	flex: 50%;
+	margin-right: 10px;
+	${mediaKey.small} {
+		margin-right: 0;
+	}
+`;
+const noResultsCls = css`
+	flex: 50%;
+	margin-left: 10px;
+	${mediaKey.small} {
+		margin-left: 0;
+		margin-top: 20px;
+	}
+`;
+
+const AdvancedAnalytics = ({
+	searchVolume,
+	popularSearches,
+	noResults,
+	popularResults,
+	popularFilters,
+	plan,
+	displayReplaySearch,
+	handleReplaySearch,
+	onClickViewAll,
+}) => {
+	// useLayoutEffect(() => {
+	// 	console.log('analytics fetched');
+	// 	// fetchAnalytics();
+	// }, []);
+
+	return (
+		<Fragment>
+			<SearchVolumeChart height={300} data={searchVolume} />
+			<Flex css={results}>
+				<div css={searchCls}>
+					<Searches
+						href="popular-searches"
+						dataSource={getFilteredResults(popularSearches).map((item) => ({
+							...item,
+							handleReplaySearch,
+						}))}
+						columns={popularSearchesCol(plan, displayReplaySearch)}
+						title="Popular Searches"
+						css="height: 100%"
+						onClickViewAll={(onClickViewAll && onClickViewAll.popularSearches) || null}
+					/>
+				</div>
+				<div css={noResultsCls}>
+					<Searches
+						href="no-results-searches"
+						dataSource={getFilteredResults(noResults).map((item) => ({
+							...item,
+							handleReplaySearch,
+						}))}
+						columns={noResultsFull(plan, displayReplaySearch)}
+						title="No Result Searches"
+						css="height: 100%"
+						onClickViewAll={(onClickViewAll && onClickViewAll.noResultsSearch) || null}
+					/>
+				</div>
+			</Flex>
+			{plan === 'growth' && (
+				<Flex css={results}>
+					<div css={searchCls}>
+						<Searches
+							dataSource={getFilteredResults(popularResults).map((item) => ({
+								...item,
+								handleReplaySearch,
+							}))}
+							columns={popularResultsCol(plan, displayReplaySearch)}
+							title="Popular Results"
+							href="popular-results"
+							css="height: 100%"
+							onClickViewAll={
+								(onClickViewAll && onClickViewAll.popularResults) || null
+							}
+							breakWord
+						/>
+					</div>
+					<div css={noResultsCls}>
+						<Searches
+							dataSource={getFilteredResults(popularFilters).map((item) => ({
+								...item,
+								handleReplaySearch,
+							}))}
+							columns={popularFiltersCol(plan, displayReplaySearch)}
+							title="Popular Filters"
+							href="popular-filters"
+							css="height: 100%"
+							onClickViewAll={
+								(onClickViewAll && onClickViewAll.popularFilters) || null
+							}
+							breakWord
+						/>
+					</div>
+				</Flex>
+			)}
+		</Fragment>
+	);
+};
+
+AdvancedAnalytics.defaultProps = {
+	searchVolume: [],
+	popularSearches: [],
+	noResults: [],
+	popularResults: [],
+	popularFilters: [],
+	displayReplaySearch: false,
+	onClickViewAll: null,
+};
+
+AdvancedAnalytics.propTypes = {
+	searchVolume: PropTypes.array,
+	popularSearches: PropTypes.array,
+	noResults: PropTypes.array,
+	popularResults: PropTypes.array,
+	popularFilters: PropTypes.array,
+	plan: PropTypes.string.isRequired,
+	displayReplaySearch: PropTypes.bool,
+	handleReplaySearch: PropTypes.func.isRequired,
+	onClickViewAll: PropTypes.shape({
+		popularFilters: PropTypes.func,
+		popularResults: PropTypes.func,
+		popularSearches: PropTypes.func,
+		noResultsSearch: PropTypes.func,
+	}),
+};
+
+export default React.memo(AdvancedAnalytics);

--- a/components/analytics/components/Analytics.js
+++ b/components/analytics/components/Analytics.js
@@ -1,48 +1,15 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Spin, Icon, Card } from 'antd';
 import PropTypes from 'prop-types';
-import { css } from 'react-emotion';
 import Filter from './Filter';
 import Flex from '../../shared/Flex';
-import {
-	popularFiltersCol,
-	popularResultsCol,
-	popularSearchesCol,
-	noResultsFull,
-	inViewPort,
-} from '../utils';
-import { getFilteredResults } from '../../../utils/helpers';
-import { mediaKey } from '../../../utils/media';
-import Searches from './Searches';
-import SearchVolumeChart from '../../shared/Chart/SearchVolume';
+import { inViewPort } from '../utils';
 import SearchLatency from './SearchLatency';
 import Summary from './Summary';
 import GeoDistribution from './GeoDistribution';
 import RequestDistribution from './RequestDistribution';
 import RequestLogs from './RequestLogs';
-
-const results = css`
-	width: 100%;
-	margin-top: 20px;
-	${mediaKey.small} {
-		flex-direction: column;
-	}
-`;
-const searchCls = css`
-	flex: 50%;
-	margin-right: 10px;
-	${mediaKey.small} {
-		margin-right: 0;
-	}
-`;
-const noResultsCls = css`
-	flex: 50%;
-	margin-left: 10px;
-	${mediaKey.small} {
-		margin-left: 0;
-		margin-top: 20px;
-	}
-`;
+import AdvancedAnalytics from '../AdvancedAnalytics';
 
 const handleClickBar = (payload) => {
 	const startLatency = payload.key;
@@ -84,11 +51,7 @@ const Analytics = ({
 
 	const [visibility, setVisibility] = useState({
 		'summary-component': false,
-		'search-volume-component': false,
-		'popular-searches-component': false,
-		'no-results-searches-component': false,
-		'popular-results-component': false,
-		'popular-filters-component': false,
+		'advanced-analytics-component': false,
 		'geo-distribution-component': false,
 		'search-latency-component': false,
 		'request-distribution-component': false,
@@ -98,18 +61,7 @@ const Analytics = ({
 	const tracker = () => {
 		Object.keys(visibility).forEach((key) => {
 			if (inViewPort(key) && !visibility[key]) {
-				const advancedAnalyticsComponents = {
-					'search-volume-component': true,
-					'popular-searches-component': true,
-					'no-results-searches-component': true,
-					'popular-results-component': true,
-					'popular-filters-component': true,
-				};
-				if (Object.keys(advancedAnalyticsComponents).includes(key)) {
-					setVisibility((prev) => ({ ...prev, ...advancedAnalyticsComponents }));
-				} else {
-					setVisibility((prev) => ({ ...prev, [key]: true }));
-				}
+				setVisibility((prev) => ({ ...prev, [key]: true }));
 			}
 		});
 	};
@@ -134,87 +86,23 @@ const Analytics = ({
 			>
 				{visibility['summary-component'] && <Summary filterId={filterId} />}
 			</Card>
-			<div id="search-volume-component">
-				{visibility['search-volume-component'] && (
-					<SearchVolumeChart height={300} data={searchVolume} />
+			<div id="advanced-analytics-component">
+				{visibility['advanced-analytics-component'] && (
+					<AdvancedAnalytics
+						searchVolume={searchVolume}
+						popularSearches={popularSearches}
+						noResults={noResults}
+						popularResults={popularResults}
+						popularFilters={popularFilters}
+						plan={plan}
+						displayReplaySearch={displayReplaySearch}
+						handleReplaySearch={handleReplaySearch}
+						onClickViewAll={onClickViewAll}
+					/>
 				)}
 			</div>
-			<Flex css={results}>
-				<div css={searchCls} id="popular-searches-component">
-					{visibility['popular-searches-component'] && (
-						<Searches
-							href="popular-searches"
-							dataSource={getFilteredResults(popularSearches).map((item) => ({
-								...item,
-								handleReplaySearch,
-							}))}
-							columns={popularSearchesCol(plan, displayReplaySearch)}
-							title="Popular Searches"
-							css="height: 100%"
-							onClickViewAll={
-								(onClickViewAll && onClickViewAll.popularSearches) || null
-							}
-						/>
-					)}
-				</div>
-				<div css={noResultsCls} id="no-results-searches-component">
-					{visibility['no-results-searches-component'] && (
-						<Searches
-							href="no-results-searches"
-							dataSource={getFilteredResults(noResults).map((item) => ({
-								...item,
-								handleReplaySearch,
-							}))}
-							columns={noResultsFull(plan, displayReplaySearch)}
-							title="No Result Searches"
-							css="height: 100%"
-							onClickViewAll={
-								(onClickViewAll && onClickViewAll.noResultsSearch) || null
-							}
-						/>
-					)}
-				</div>
-			</Flex>
 			{plan === 'growth' && (
 				<React.Fragment>
-					<Flex css={results}>
-						<div css={searchCls} id="popular-results-component">
-							{visibility['popular-results-component'] && (
-								<Searches
-									dataSource={getFilteredResults(popularResults).map((item) => ({
-										...item,
-										handleReplaySearch,
-									}))}
-									columns={popularResultsCol(plan, displayReplaySearch)}
-									title="Popular Results"
-									href="popular-results"
-									css="height: 100%"
-									onClickViewAll={
-										(onClickViewAll && onClickViewAll.popularResults) || null
-									}
-									breakWord
-								/>
-							)}
-						</div>
-						<div css={noResultsCls} id="popular-filters-component">
-							{visibility['popular-filters-component'] && (
-								<Searches
-									dataSource={getFilteredResults(popularFilters).map((item) => ({
-										...item,
-										handleReplaySearch,
-									}))}
-									columns={popularFiltersCol(plan, displayReplaySearch)}
-									title="Popular Filters"
-									href="popular-filters"
-									css="height: 100%"
-									onClickViewAll={
-										(onClickViewAll && onClickViewAll.popularFilters) || null
-									}
-									breakWord
-								/>
-							)}
-						</div>
-					</Flex>
 					<Flex
 						flexDirection="column"
 						css="width: 100%;margin-top: 20px"

--- a/components/analytics/components/Analytics.js
+++ b/components/analytics/components/Analytics.js
@@ -1,10 +1,16 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { Spin, Icon, Card } from 'antd';
 import PropTypes from 'prop-types';
 import { css } from 'react-emotion';
 import Filter from './Filter';
 import Flex from '../../shared/Flex';
-import { popularFiltersCol, popularResultsCol, popularSearchesCol, noResultsFull } from '../utils';
+import {
+	popularFiltersCol,
+	popularResultsCol,
+	popularSearchesCol,
+	noResultsFull,
+	inViewPort,
+} from '../utils';
 import { getFilteredResults } from '../../../utils/helpers';
 import { mediaKey } from '../../../utils/media';
 import Searches from './Searches';
@@ -13,6 +19,7 @@ import SearchLatency from './SearchLatency';
 import Summary from './Summary';
 import GeoDistribution from './GeoDistribution';
 import RequestDistribution from './RequestDistribution';
+import RequestLogs from './RequestLogs';
 
 const results = css`
 	width: 100%;
@@ -60,44 +67,49 @@ const Analytics = ({
 	displayReplaySearch,
 	handleReplaySearch,
 	filterId,
+	appName,
 }) => {
 	useEffect(() => {
 		window.addEventListener('scroll', tracker);
+		const initTracker = setTimeout(() => {
+			tracker();
+		}, 0);
 		return () => {
 			window.removeEventListener('scroll', tracker);
+			if (initTracker) {
+				clearTimeout(initTracker);
+			}
 		};
 	}, []);
 
 	const [visibility, setVisibility] = useState({
-		'geo-distribution-component': false,
-		'no-results-searches-component': false,
-		'popular-filters-component': false,
-		'popular-results-component': false,
-		'popular-searches-component': false,
-		'request-distribution-component': false,
-		'search-latency-component': false,
+		'summary-component': false,
 		'search-volume-component': false,
-		'summary-component': true,
+		'popular-searches-component': false,
+		'no-results-searches-component': false,
+		'popular-results-component': false,
+		'popular-filters-component': false,
+		'geo-distribution-component': false,
+		'search-latency-component': false,
+		'request-distribution-component': false,
+		'request-logs-component': false,
 	});
-
-	const inViewPort = (id) => {
-		if (window && document) {
-			const element = document.getElementById(id);
-			const rect = element.getBoundingClientRect();
-			return (
-				rect.top >= 0 &&
-				rect.left >= 0 &&
-				rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-				rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-			);
-		}
-		return true;
-	};
 
 	const tracker = () => {
 		Object.keys(visibility).forEach((key) => {
 			if (inViewPort(key) && !visibility[key]) {
-				setVisibility((prev) => ({ ...prev, [key]: true }));
+				const advancedAnalyticsComponents = {
+					'search-volume-component': true,
+					'popular-searches-component': true,
+					'no-results-searches-component': true,
+					'popular-results-component': true,
+					'popular-filters-component': true,
+				};
+				if (Object.keys(advancedAnalyticsComponents).includes(key)) {
+					setVisibility((prev) => ({ ...prev, ...advancedAnalyticsComponents }));
+				} else {
+					setVisibility((prev) => ({ ...prev, [key]: true }));
+				}
 			}
 		});
 	};
@@ -234,6 +246,15 @@ const Analytics = ({
 							<RequestDistribution filterId={filterId} displayFilter={false} />
 						)}
 					</Flex>
+					<Flex
+						flexDirection="column"
+						css="width: 100%;margin-top: 20px"
+						id="request-logs-component"
+					>
+						{visibility['request-logs-component'] && (
+							<RequestLogs displayFilter={false} appName={appName} />
+						)}
+					</Flex>
 				</React.Fragment>
 			)}
 		</React.Fragment>
@@ -249,6 +270,7 @@ Analytics.defaultProps = {
 	onClickViewAll: null,
 	displayReplaySearch: false,
 	filterId: undefined,
+	appName: undefined,
 };
 Analytics.propTypes = {
 	onClickViewAll: PropTypes.shape({
@@ -267,6 +289,7 @@ Analytics.propTypes = {
 	searchVolume: PropTypes.array,
 	popularResults: PropTypes.array,
 	popularFilters: PropTypes.array,
+	appName: PropTypes.string,
 };
 
 export default Analytics;

--- a/components/analytics/components/Analytics.js
+++ b/components/analytics/components/Analytics.js
@@ -23,11 +23,6 @@ const handleClickBar = (payload) => {
 	window.location.href = newURL;
 };
 const Analytics = ({
-	noResults,
-	popularSearches,
-	searchVolume,
-	popularFilters,
-	popularResults,
 	plan,
 	loading,
 	onClickViewAll,
@@ -89,11 +84,6 @@ const Analytics = ({
 			<div id="advanced-analytics-component">
 				{visibility['advanced-analytics-component'] && (
 					<AdvancedAnalytics
-						searchVolume={searchVolume}
-						popularSearches={popularSearches}
-						noResults={noResults}
-						popularResults={popularResults}
-						popularFilters={popularFilters}
 						plan={plan}
 						displayReplaySearch={displayReplaySearch}
 						handleReplaySearch={handleReplaySearch}
@@ -150,11 +140,6 @@ const Analytics = ({
 };
 Analytics.defaultProps = {
 	loading: false,
-	noResults: [],
-	popularSearches: [],
-	searchVolume: [],
-	popularResults: [],
-	popularFilters: [],
 	onClickViewAll: null,
 	displayReplaySearch: false,
 	filterId: undefined,
@@ -170,13 +155,8 @@ Analytics.propTypes = {
 	filterId: PropTypes.string,
 	loading: PropTypes.bool,
 	displayReplaySearch: PropTypes.bool,
-	noResults: PropTypes.array,
-	popularSearches: PropTypes.array,
 	plan: PropTypes.string.isRequired,
 	handleReplaySearch: PropTypes.func.isRequired,
-	searchVolume: PropTypes.array,
-	popularResults: PropTypes.array,
-	popularFilters: PropTypes.array,
 	appName: PropTypes.string,
 };
 

--- a/components/analytics/components/Analytics.js
+++ b/components/analytics/components/Analytics.js
@@ -88,6 +88,7 @@ const Analytics = ({
 						displayReplaySearch={displayReplaySearch}
 						handleReplaySearch={handleReplaySearch}
 						onClickViewAll={onClickViewAll}
+						filterId={filterId}
 					/>
 				)}
 			</div>

--- a/components/analytics/index.js
+++ b/components/analytics/index.js
@@ -5,31 +5,8 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import Analytics from './components/Analytics';
 import { getAppAnalytics, setSearchState } from '../../modules/actions';
-import Loader from '../shared/Loader/Spinner';
-import { getAppAnalyticsByName } from '../../modules/selectors';
 
-let prevProps = {};
 class Main extends React.Component {
-	state = {
-		isLoading: true,
-	};
-
-	static getDerivedStateFromProps(props) {
-		if (prevProps.isFetching && !props.isFetching) {
-			prevProps = props;
-			return {
-				isLoading: false,
-			};
-		}
-		prevProps = props;
-		return null;
-	}
-
-	componentDidMount() {
-		// Comment out the below code to test paid user
-		this.fetchAnalytics();
-	}
-
 	shouldComponentUpdate(oldProps) {
 		const { isInsightsSidebarOpen } = this.props;
 		if (isInsightsSidebarOpen !== oldProps.isInsightsSidebarOpen) {
@@ -62,31 +39,13 @@ class Main extends React.Component {
 	};
 
 	render() {
-		const { isLoading } = this.state;
-		const {
-			noResults,
-			popularSearches,
-			searchVolume,
-			popularResults,
-			popularFilters,
-			onClickViewAll,
-			displayReplaySearch,
-			filterId,
-		} = this.props;
+		const { onClickViewAll, displayReplaySearch, filterId } = this.props;
 		const { appName, chartWidth, plan } = this.props;
-		if (isLoading) {
-			return <Loader />;
-		}
 		return (
 			<Analytics
 				filterId={filterId}
-				noResults={noResults}
 				chartWidth={chartWidth}
 				plan={plan}
-				popularSearches={popularSearches}
-				popularFilters={popularFilters}
-				popularResults={popularResults}
-				searchVolume={searchVolume}
 				onClickViewAll={onClickViewAll}
 				displayReplaySearch={displayReplaySearch}
 				handleReplaySearch={this.handleReplaySearch}
@@ -112,12 +71,6 @@ Main.propTypes = {
 	plan: PropTypes.string.isRequired,
 	displayReplaySearch: PropTypes.bool,
 	fetchAppAnalytics: PropTypes.func.isRequired,
-	popularSearches: PropTypes.array.isRequired,
-	popularResults: PropTypes.array.isRequired,
-	popularFilters: PropTypes.array.isRequired,
-	searchVolume: PropTypes.array.isRequired,
-	noResults: PropTypes.array.isRequired,
-	isFetching: PropTypes.bool.isRequired, //eslint-disable-line
 	saveState: PropTypes.func.isRequired,
 	handleReplayClick: PropTypes.func,
 	history: PropTypes.object.isRequired,
@@ -126,25 +79,9 @@ Main.propTypes = {
 	isInsightsSidebarOpen: PropTypes.bool,
 };
 const mapStateToProps = (state, props) => {
-	const analyticsArr = Array.isArray(getAppAnalyticsByName(state))
-		? getAppAnalyticsByName(state)
-		: [];
-	let appAnalytics = {};
-	analyticsArr.forEach((item) => {
-		appAnalytics = {
-			...appAnalytics,
-			...item,
-		};
-	});
 	return {
 		plan: 'growth',
 		appName: get(state, '$getCurrentApp.name'),
-		popularSearches: get(appAnalytics, 'popular_searches', []),
-		popularResults: get(appAnalytics, 'popular_results', []),
-		popularFilters: get(appAnalytics, 'popular_filters', []),
-		searchVolume: get(appAnalytics, 'search_histogram', []),
-		noResults: get(appAnalytics, 'no_results_searches', []),
-		isFetching: get(state, '$getAppAnalytics.isFetching'),
 		filters: get(state, `$getSelectedFilters.${props.filterId}`),
 		isInsightsSidebarOpen: get(state, '$getAppAnalyticsInsights.isOpen', false),
 	};

--- a/components/analytics/index.js
+++ b/components/analytics/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import Analytics from './components/Analytics';
-import { getAppAnalytics, setSearchState } from '../../modules/actions';
+import { setSearchState } from '../../modules/actions';
 
 class Main extends React.Component {
 	shouldComponentUpdate(oldProps) {
@@ -15,18 +15,6 @@ class Main extends React.Component {
 
 		return true;
 	}
-
-	componentDidUpdate(previousProps) {
-		const { filters } = this.props;
-		if (filters && JSON.stringify(previousProps.filters) !== JSON.stringify(filters)) {
-			this.fetchAnalytics();
-		}
-	}
-
-	fetchAnalytics = () => {
-		const { fetchAppAnalytics } = this.props;
-		fetchAppAnalytics();
-	};
 
 	handleReplaySearch = (searchState) => {
 		const { saveState, history, appName, handleReplayClick } = this.props;
@@ -61,7 +49,6 @@ Main.defaultProps = {
 	onClickViewAll: null,
 	displayReplaySearch: false,
 	filterId: undefined,
-	filters: undefined,
 	isInsightsSidebarOpen: false,
 };
 Main.propTypes = {
@@ -70,24 +57,20 @@ Main.propTypes = {
 	chartWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 	plan: PropTypes.string.isRequired,
 	displayReplaySearch: PropTypes.bool,
-	fetchAppAnalytics: PropTypes.func.isRequired,
 	saveState: PropTypes.func.isRequired,
 	handleReplayClick: PropTypes.func,
 	history: PropTypes.object.isRequired,
 	filterId: PropTypes.string,
-	filters: PropTypes.object,
 	isInsightsSidebarOpen: PropTypes.bool,
 };
-const mapStateToProps = (state, props) => {
+const mapStateToProps = (state) => {
 	return {
 		plan: 'growth',
 		appName: get(state, '$getCurrentApp.name'),
-		filters: get(state, `$getSelectedFilters.${props.filterId}`),
 		isInsightsSidebarOpen: get(state, '$getAppAnalyticsInsights.isOpen', false),
 	};
 };
-const mapDispatchToProps = (dispatch, props) => ({
-	fetchAppAnalytics: (appName) => dispatch(getAppAnalytics(appName, props.filterId)),
+const mapDispatchToProps = (dispatch) => ({
 	saveState: (state) => dispatch(setSearchState(state)),
 });
 export default connect(mapStateToProps, mapDispatchToProps)(withRouter(Main));

--- a/components/analytics/index.js
+++ b/components/analytics/index.js
@@ -7,7 +7,6 @@ import Analytics from './components/Analytics';
 import { getAppAnalytics, setSearchState } from '../../modules/actions';
 import Loader from '../shared/Loader/Spinner';
 import { getAppAnalyticsByName } from '../../modules/selectors';
-import RequestLogs from './components/RequestLogs';
 
 let prevProps = {};
 class Main extends React.Component {
@@ -79,24 +78,20 @@ class Main extends React.Component {
 			return <Loader />;
 		}
 		return (
-			<React.Fragment>
-				<Analytics
-					filterId={filterId}
-					noResults={noResults}
-					chartWidth={chartWidth}
-					plan={plan}
-					popularSearches={popularSearches}
-					popularFilters={popularFilters}
-					popularResults={popularResults}
-					searchVolume={searchVolume}
-					onClickViewAll={onClickViewAll}
-					displayReplaySearch={displayReplaySearch}
-					handleReplaySearch={this.handleReplaySearch}
-				/>
-				<div css="margin-top: 20px">
-					<RequestLogs displayFilter={false} appName={appName} />
-				</div>
-			</React.Fragment>
+			<Analytics
+				filterId={filterId}
+				noResults={noResults}
+				chartWidth={chartWidth}
+				plan={plan}
+				popularSearches={popularSearches}
+				popularFilters={popularFilters}
+				popularResults={popularResults}
+				searchVolume={searchVolume}
+				onClickViewAll={onClickViewAll}
+				displayReplaySearch={displayReplaySearch}
+				handleReplaySearch={this.handleReplaySearch}
+				appName={appName}
+			/>
 		);
 	}
 }

--- a/components/analytics/utils.js
+++ b/components/analytics/utils.js
@@ -962,13 +962,16 @@ export function getRecentResults(appName, filters, arcVersion) {
 export function inViewPort(id) {
 	if (window && document) {
 		const element = document.getElementById(id);
-		const rect = element.getBoundingClientRect();
-		return (
-			rect.top >= 0 &&
-			rect.left >= 0 &&
-			rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-			rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-		);
+		if (element) {
+			const rect = element.getBoundingClientRect();
+			return (
+				rect.top >= 0 &&
+				rect.left >= 0 &&
+				rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+				rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+			);
+		}
+		return false;
 	}
 	return true;
 }

--- a/components/analytics/utils.js
+++ b/components/analytics/utils.js
@@ -646,7 +646,13 @@ export function getAnalyticsSummary(appName, filters, arcVersion) {
  * @param {string} appName
  */
 // eslint-disable-next-line
-export function getPopularSearches(appName, clickanalytics = true, size = 100, filters, arcVersion) {
+export function getPopularSearches(
+	appName,
+	clickanalytics = true,
+	size = 100,
+	filters,
+	arcVersion,
+) {
 	return doGet(
 		`${getURL()}/_analytics/${getApp(appName)}popular-searches${getQueryParams(
 			{
@@ -952,4 +958,17 @@ export function getRecentResults(appName, filters, arcVersion) {
 			arcVersion,
 		)}`,
 	);
+}
+export function inViewPort(id) {
+	if (window && document) {
+		const element = document.getElementById(id);
+		const rect = element.getBoundingClientRect();
+		return (
+			rect.top >= 0 &&
+			rect.left >= 0 &&
+			rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+			rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+		);
+	}
+	return true;
 }


### PR DESCRIPTION
- Issue Type - Bug

- Description - The analytics overview page was making all the requests and rendering all its children components as soon as the component mounts which increases the total load time for the page. Added ids to all the components for conditional rendering for components that are once present in the viewport.

- Please look into the following PR for further reference - appbaseio-confidential/arc-dashboard#327