### PR TITLE
feat: added x-search-client header in relevant api calls

### DIFF
--- a/components/analytics/utils.js
+++ b/components/analytics/utils.js
@@ -7,6 +7,7 @@ import get from 'lodash/get';
 // import mockProfile from './components/mockProfile';
 import { doGet, doPut } from '../../utils/requestService';
 import Flex from '../shared/Flex';
+import { X_SEARCH_CLIENT } from '../../../constants';
 import { getURL } from '../../../constants/config';
 import { getUrlParams } from '../../../utils/helper';
 import { versionCompare } from '../../utils/helpers';
@@ -586,6 +587,9 @@ export function getAnalytics(appName, filters, arcVersion) {
 			},
 			arcVersion,
 		)}`,
+		{
+			'x-search-client': X_SEARCH_CLIENT,
+		},
 	);
 }
 /**
@@ -599,6 +603,9 @@ export function getSearchLatency(appName, filters, arcVersion) {
 			arcVersion,
 			false,
 		)}`,
+		{
+			'x-search-client': X_SEARCH_CLIENT,
+		},
 	);
 }
 
@@ -618,6 +625,9 @@ export function getQueryOverview(appName, filters, query, arcVersion) {
 			},
 			arcVersion,
 		)}`,
+		{
+			'x-search-client': X_SEARCH_CLIENT,
+		},
 	);
 }
 /**
@@ -630,6 +640,9 @@ export function getGeoDistribution(appName, filters, arcVersion) {
 			filters,
 			arcVersion,
 		)}`,
+		{
+			'x-search-client': X_SEARCH_CLIENT,
+		},
 	);
 }
 /**
@@ -639,6 +652,9 @@ export function getGeoDistribution(appName, filters, arcVersion) {
 export function getAnalyticsSummary(appName, filters, arcVersion) {
 	return doGet(
 		`${getURL()}/_analytics/${getApp(appName)}summary${getQueryParams(filters, arcVersion)}`,
+		{
+			'x-search-client': X_SEARCH_CLIENT,
+		},
 	);
 }
 /**
@@ -662,6 +678,9 @@ export function getPopularSearches(
 			},
 			arcVersion,
 		)}`,
+		{
+			'x-search-client': X_SEARCH_CLIENT,
+		},
 	);
 }
 /**
@@ -677,6 +696,9 @@ export function getNoResultSearches(appName, size = 100, filters, arcVersion) {
 			},
 			arcVersion,
 		)}`,
+		{
+			'x-search-client': X_SEARCH_CLIENT,
+		},
 	);
 }
 // eslint-disable-next-line
@@ -691,6 +713,9 @@ export function getPopularResults(appName, clickAnalytics = true, size = 100, fi
 			},
 			arcVersion,
 		)}`,
+		{
+			'x-search-client': X_SEARCH_CLIENT,
+		},
 	);
 }
 /**
@@ -704,6 +729,9 @@ export function getRequestDistribution(appName, filters, arcVersion) {
 			filters,
 			arcVersion,
 		)}`,
+		{
+			'x-search-client': X_SEARCH_CLIENT,
+		},
 	);
 }
 // eslint-disable-next-line
@@ -717,6 +745,9 @@ export function getPopularFilters(appName, clickAnalytics = true, size = 100, fi
 			},
 			arcVersion,
 		)}`,
+		{
+			'x-search-client': X_SEARCH_CLIENT,
+		},
 	);
 }
 
@@ -756,6 +787,9 @@ export function getRequestLogs(
 			arcVersion,
 			false,
 		)}`,
+		{
+			'x-search-client': X_SEARCH_CLIENT,
+		},
 	);
 }
 
@@ -765,7 +799,9 @@ export function getRequestLogs(
  */
 export function getAnalyticsInsights(appName) {
 	const ACC_API = getURL();
-	return doGet(`${ACC_API}/_analytics/${getApp(appName)}insights`);
+	return doGet(`${ACC_API}/_analytics/${getApp(appName)}insights`, {
+		'x-search-client': X_SEARCH_CLIENT,
+	});
 }
 
 /**
@@ -776,10 +812,16 @@ export function getAnalyticsInsights(appName) {
  */
 export function updateAnalyticsInsights({ id, status, appName }) {
 	const ACC_API = getURL();
-	return doPut(`${ACC_API}/_analytics/${getApp(appName)}insight-status`, {
-		id,
-		status,
-	});
+	return doPut(
+		`${ACC_API}/_analytics/${getApp(appName)}insight-status`,
+		{
+			id,
+			status,
+		},
+		{
+			'x-search-client': X_SEARCH_CLIENT,
+		},
+	);
 }
 
 // Banner messages
@@ -943,6 +985,9 @@ export function getRecentSearches(appName, filters, arcVersion) {
 			},
 			arcVersion,
 		)}`,
+		{
+			'x-search-client': X_SEARCH_CLIENT,
+		},
 	);
 }
 /**
@@ -960,6 +1005,9 @@ export function getRecentResults(appName, filters, arcVersion) {
 			},
 			arcVersion,
 		)}`,
+		{
+			'x-search-client': X_SEARCH_CLIENT,
+		},
 	);
 }
 export function inViewPort(id) {

--- a/modules/actions/cache.js
+++ b/modules/actions/cache.js
@@ -2,12 +2,15 @@ import { createAction } from './utils';
 import AppConstants from '../constants';
 import { getURL } from '../../../constants/config';
 import { doGet, doPost } from '../../utils/requestService';
+import { X_SEARCH_CLIENT } from '../../../constants';
 
 export function getCachePreferences() {
 	return (dispatch) => {
 		dispatch(createAction(AppConstants.APP.CACHE.GET_PREFERENCES));
 		const ACC_API = getURL();
-		return doGet(`${ACC_API}/_cache/preferences`)
+		return doGet(`${ACC_API}/_cache/preferences`, {
+			'x-search-client': X_SEARCH_CLIENT,
+		})
 			.then((res) =>
 				dispatch(createAction(AppConstants.APP.CACHE.GET_PREFERENCES_SUCCESS, res, null)),
 			)
@@ -21,7 +24,9 @@ export function saveCachePreferences(payload) {
 	return (dispatch) => {
 		dispatch(createAction(AppConstants.APP.CACHE.SAVE_PREFERENCES));
 		const ACC_API = getURL();
-		return doPost(`${ACC_API}/_cache/preferences`, payload)
+		return doPost(`${ACC_API}/_cache/preferences`, payload, {
+			'x-search-client': X_SEARCH_CLIENT,
+		})
 			.then((res) =>
 				dispatch(createAction(AppConstants.APP.CACHE.SAVE_PREFERENCES_SUCCESS, res)),
 			)
@@ -35,7 +40,9 @@ export function evictCache() {
 	return (dispatch) => {
 		dispatch(createAction(AppConstants.APP.CACHE.EVICT));
 		const ACC_API = getURL();
-		return doPost(`${ACC_API}/_cache/evict`)
+		return doPost(`${ACC_API}/_cache/evict`, null, {
+			'x-search-client': X_SEARCH_CLIENT,
+		})
 			.then((res) => dispatch(createAction(AppConstants.APP.CACHE.EVICT_SUCCESS, res)))
 			.catch((error) =>
 				dispatch(createAction(AppConstants.APP.CACHE.EVICT_ERROR, null, error)),

--- a/modules/actions/filter.js
+++ b/modules/actions/filter.js
@@ -4,6 +4,7 @@ import AppConstants from '../constants';
 import { doGet } from '../../utils/requestService';
 import { getURL } from '../../../constants/config';
 import { getApp, ANALYTICS_ROOT_FILTER_ID } from '../../components/analytics/utils';
+import { X_SEARCH_CLIENT } from '../../../constants';
 
 export function setFilterValue(filterId, filterKey, filterValue) {
 	return createAction(AppConstants.APP.FILTER.SET_FILTER_VALUE, {
@@ -36,7 +37,9 @@ export function getFilterLabels() {
 	return (dispatch) => {
 		const ACC_API = getURL();
 		dispatch(createAction(AppConstants.APP.FILTER.GET_LABEL));
-		return doGet(`${ACC_API}/_analytics/filter-labels`)
+		return doGet(`${ACC_API}/_analytics/filter-labels`, {
+			'x-search-client': X_SEARCH_CLIENT,
+		})
 			.then((res) => dispatch(createAction(AppConstants.APP.FILTER.GET_LABEL_SUCCESS, res)))
 			.catch((error) =>
 				dispatch(createAction(AppConstants.APP.FILTER.GET_LABEL_ERROR, null, error)),
@@ -53,6 +56,9 @@ export function getFilterValues(label, prefix = '', name) {
 			`${ACC_API}/_analytics/${getApp(appName)}filter-values/${label}${
 				prefix.trim() ? `?prefix=${encodeURIComponent(prefix)}` : ''
 			}`,
+			{
+				'x-search-client': X_SEARCH_CLIENT,
+			},
 		)
 			.then((res) =>
 				dispatch(

--- a/modules/actions/uibuilder.js
+++ b/modules/actions/uibuilder.js
@@ -3,13 +3,16 @@ import { createAction } from './utils';
 import AppConstants from '../constants';
 import { getURL } from '../../../constants/config';
 import { doGet, doPut, doDelete } from '../../utils/requestService';
+import { X_SEARCH_CLIENT } from '../../../constants';
 
 export function getSearchPreferences(name) {
 	return (dispatch, getState) => {
 		dispatch(createAction(AppConstants.APP.UI_BUILDER.SEARCH_PREFERENCES.GET));
 		const ACC_API = getURL();
 		const appName = name || get(getState(), '$getCurrentApp.name', 'default');
-		return doGet(`${ACC_API}/_uibuilder/${appName}/search`)
+		return doGet(`${ACC_API}/_uibuilder/${appName}/search`, {
+			'x-search-client': X_SEARCH_CLIENT,
+		})
 			.then((res) =>
 				dispatch(
 					createAction(
@@ -39,7 +42,9 @@ export function saveSearchPreferences(payload, name) {
 		dispatch(createAction(AppConstants.APP.UI_BUILDER.SEARCH_PREFERENCES.SAVE));
 		const ACC_API = getURL();
 		const appName = name || get(getState(), '$getCurrentApp.name', 'default');
-		return doPut(`${ACC_API}/_uibuilder/${appName}/search`, payload)
+		return doPut(`${ACC_API}/_uibuilder/${appName}/search`, payload, {
+			'x-search-client': X_SEARCH_CLIENT,
+		})
 			.then((res) => {
 				dispatch(
 					createAction(
@@ -80,7 +85,9 @@ export function deleteSearchPreferences(defaultPreferences, name) {
 		dispatch(createAction(AppConstants.APP.UI_BUILDER.SEARCH_PREFERENCES.DELETE));
 		const ACC_API = getURL();
 		const appName = name || get(getState(), '$getCurrentApp.name', 'default');
-		return doDelete(`${ACC_API}/_uibuilder/${appName}/search`)
+		return doDelete(`${ACC_API}/_uibuilder/${appName}/search`, {
+			'x-search-client': X_SEARCH_CLIENT,
+		})
 			.then((res) => {
 				dispatch(
 					createAction(
@@ -120,7 +127,9 @@ export function getRecommendationsPreferences(name) {
 		dispatch(createAction(AppConstants.APP.UI_BUILDER.RECOMMENDATION_PREFERENCES.GET));
 		const ACC_API = getURL();
 		const appName = name || get(getState(), '$getCurrentApp.name', 'default');
-		return doGet(`${ACC_API}/_uibuilder/${appName}/recommendations`)
+		return doGet(`${ACC_API}/_uibuilder/${appName}/recommendations`, {
+			'x-search-client': X_SEARCH_CLIENT,
+		})
 			.then((res) =>
 				dispatch(
 					createAction(
@@ -150,7 +159,9 @@ export function saveRecommendationsPreferences(payload, name) {
 		dispatch(createAction(AppConstants.APP.UI_BUILDER.RECOMMENDATION_PREFERENCES.SAVE));
 		const ACC_API = getURL();
 		const appName = name || get(getState(), '$getCurrentApp.name', 'default');
-		return doPut(`${ACC_API}/_uibuilder/${appName}/recommendations`, payload)
+		return doPut(`${ACC_API}/_uibuilder/${appName}/recommendations`, payload, {
+			'x-search-client': X_SEARCH_CLIENT,
+		})
 			.then((res) => {
 				dispatch(
 					createAction(
@@ -190,7 +201,9 @@ export function deleteRecommendationsPreferences(defaultPreferences, name) {
 		dispatch(createAction(AppConstants.APP.UI_BUILDER.RECOMMENDATION_PREFERENCES.DELETE));
 		const ACC_API = getURL();
 		const appName = name || get(getState(), '$getCurrentApp.name', 'default');
-		return doDelete(`${ACC_API}/_uibuilder/${appName}/recommendations`)
+		return doDelete(`${ACC_API}/_uibuilder/${appName}/recommendations`, {
+			'x-search-client': X_SEARCH_CLIENT,
+		})
 			.then((res) => {
 				dispatch(
 					createAction(

--- a/utils/app.js
+++ b/utils/app.js
@@ -2,6 +2,7 @@ import get from 'lodash/get';
 import { doDelete, doPatch, doGet, doPost, doPut } from './requestService';
 import { getApp } from '../components/analytics/utils';
 import { getURL } from '../../constants/config';
+import { X_SEARCH_CLIENT } from '../../constants';
 
 export const transferOwnership = (appId, info) => {
 	const ACC_API = getURL();
@@ -328,6 +329,7 @@ export const getSearchSettings = (name) => {
 	return doGet(`${ACC_API}/_searchrelevancy/${name}`, {
 		'Content-Type': 'application/json',
 		Authorization: `Basic ${authToken}`,
+		'x-search-client': X_SEARCH_CLIENT,
 	});
 };
 
@@ -337,6 +339,7 @@ export const getDefaultSearchSettings = () => {
 	return doGet(`${ACC_API}/_searchrelevancy/_default`, {
 		'Content-Type': 'application/json',
 		Authorization: `Basic ${authToken}`,
+		'x-search-client': X_SEARCH_CLIENT,
 	});
 };
 
@@ -346,13 +349,17 @@ export const putSearchSettings = (name, payload) => {
 	return doPut(`${ACC_API}/_searchrelevancy/${name}`, payload, {
 		'Content-Type': 'application/json',
 		Authorization: `Basic ${authToken}`,
+		'x-search-client': X_SEARCH_CLIENT,
 	});
 };
 
 export const deleteSearchSettings = (name) => {
 	const ACC_API = getURL();
 	const authToken = getAuthToken();
-	return doDelete(`${ACC_API}/_searchrelevancy/${name}`, { Authorization: `Basic ${authToken}` });
+	return doDelete(`${ACC_API}/_searchrelevancy/${name}`, {
+		Authorization: `Basic ${authToken}`,
+		'x-search-client': X_SEARCH_CLIENT,
+	});
 };
 
 export const getGradeMetrics = (indices, page) => {


### PR DESCRIPTION
**PR Type:** Feature

**Description:** Enabling telemetry using relevant headers (`x-search-client`) in selected endpoints for arc-dashboard.

[🔗   Notion Card](https://www.notion.so/appbase/07e54a4a4be74c8fb21d7c47efddbc1d)

[🔗   Related PR](https://github.com/appbaseio-confidential/arc-dashboard/pull/355)

- Endpoints References
    - https://arc-api.appbase.io/#fa69cbac-143b-4ce1-881b-c8287ac48d37
    - https://arc-api.appbase.io/#87beab91-7204-4654-90b5-0244dc374e6a
    - https://arc-api.appbase.io/#37279183-6d6e-4432-9fac-17fa2bb357d2
    - https://arc-api.appbase.io/#b726e1b7-9218-4ecb-ac90-692377c0123a
    - https://arc-api.appbase.io/#3eafdb75-64b5-4e3a-b3e1-1638500694ef
 