### PR TITLE
fix: api endpoint for validate-query

### DIFF
--- a/modules/actions/storedQueries.js
+++ b/modules/actions/storedQueries.js
@@ -57,11 +57,11 @@ export function deleteAppStoredQuery(storedQueryId) {
 	};
 }
 
-export function validateAppStoredQuery(storedQueryId, payload) {
+export function validateAppStoredQuery(payload) {
 	return (dispatch) => {
 		dispatch(createAction(AppConstants.APP.STORED_QUERIES.VALIDATE));
 		const ACC_API = getURL();
-		const url = `${ACC_API}/_storedquery/${storedQueryId}/validate`;
+		const url = `${ACC_API}/_storedquery/validate`;
 		return doPost(url, payload, undefined, undefined, undefined, true)
 			.then((res) =>
 				dispatch(createAction(AppConstants.APP.STORED_QUERIES.VALIDATE_SUCCESS, res)),


### PR DESCRIPTION
**PR Type:** Fix

**Description:** Followup of #269, fixed the validate endpoint here.

[🗂️   Notion Card](https://www.notion.so/appbase/Stored-Queries-Extend-ReactiveSearch-API-and-direct-REST-API-template-generation-db6a7a485d8b4ea3925bfae7885e0534)

[🎥   Loom](https://www.loom.com/share/5b305eaf0d1f43bb85a0a8c796d797e0)

[🔗   Related PR](https://github.com/appbaseio-confidential/arc-dashboard/pull/358)
