### PR TITLE
fix: recent results type error

### DIFF
--- a/components/analytics/components/RecentResults.js
+++ b/components/analytics/components/RecentResults.js
@@ -42,13 +42,13 @@ class RecentResults extends React.Component {
 
 	getResults = () => {
 		const { appName, recentResults } = this.props;
+		let results = [];
 		if (recentResults && recentResults[appName]) {
-			return recentResults[appName];
+			results = recentResults[appName];
+		} else if (recentResults && recentResults.default) {
+			results = recentResults.default;
 		}
-		if (recentResults && recentResults.default) {
-			return recentResults.default;
-		}
-		return [];
+		return Array.isArray(results) ? results : [];
 	};
 
 	render() {


### PR DESCRIPTION
**PR Type**: `Bug Fix`

**Description:** Reported by @siddharthlatest the UI broke for a datatype which wasn't an array.

![https://i.imgur.com/zGJr1OZ.png](https://i.imgur.com/zGJr1OZ.png)

- **Console error:**

    ```bash
    TypeError: this.getResults(...).map is not a function
        at E.render (RecentResults.js:68)
        at Li (vendor.3c8d5605fb577ab9a238.bundle.js:1)
        at Fi (vendor.3c8d5605fb577ab9a238.bundle.js:1)
        at mc (vendor.3c8d5605fb577ab9a238.bundle.js:1)
        at ul (vendor.3c8d5605fb577ab9a238.bundle.js:1)
        at cl (vendor.3c8d5605fb577ab9a238.bundle.js:1)
        at Jc (vendor.3c8d5605fb577ab9a238.bundle.js:1)
        at vendor.3c8d5605fb577ab9a238.bundle.js:1
        at t.unstable_runWithPriority (main.214d59bcbfc3fde832bb.bundle.js:1)
        at Uo (vendor.3c8d5605fb577ab9a238.bundle.js:1)
        at qo (vendor.3c8d5605fb577ab9a238.bundle.js:1)
        at Qo (vendor.3c8d5605fb577ab9a238.bundle.js:1)
        at I (vendor.3c8d5605fb577ab9a238.bundle.js:1)
        at Gt (vendor.3c8d5605fb577ab9a238.bundle.js:1)
        at HTMLDocument.r (main.214d59bcbfc3fde832bb.bundle.js:1)
    ```