### PR TITLE
fix: remove beautify button when readonly mode in monaco editor

### DIFF
--- a/components/SearchSandbox/containers/MonacoEditor.js
+++ b/components/SearchSandbox/containers/MonacoEditor.js
@@ -59,14 +59,16 @@ const Monaco = ({
 
 	return (
 		<div className={editorContainer} style={{ width, height }}>
-			<button
-				type="button"
-				onClick={() => {
-					tidyCode(editorRef.current);
-				}}
-			>
-				Beautify
-			</button>
+			{!readOnly && (
+				<button
+					type="button"
+					onClick={() => {
+						tidyCode(editorRef.current);
+					}}
+				>
+					Beautify
+				</button>
+			)}
 			<Editor
 				theme={theme}
 				defaultValue={defaultValue}


### PR DESCRIPTION
**PR Type: ** Bugfix

**Description:** The beautify button is made to disappear if the Monaco editor is used in a read-only mode.

![image](https://user-images.githubusercontent.com/57627350/133761309-08e2aaf5-7e27-46a9-b155-fe965b599f74.png)
