### PR TITLE
fix: monaco editor - onblur method recevied `undefined`

### DIFF
--- a/components/SearchSandbox/containers/MonacoEditor.js
+++ b/components/SearchSandbox/containers/MonacoEditor.js
@@ -93,7 +93,7 @@ Monaco.defaultProps = {
 	value: '',
 	defaultValue: '',
 	onChange: undefined,
-	onBlur: undefined,
+	onBlur: () => {},
 	options: {},
 	theme: 'light',
 	height: '100%',

--- a/components/SearchSandbox/containers/MonacoEditor.js
+++ b/components/SearchSandbox/containers/MonacoEditor.js
@@ -49,7 +49,9 @@ const Monaco = ({
 	const handleEditorDidMount = (editor) => {
 		editorRef.current = editor;
 		editor.onDidBlurEditorWidget(() => {
-			onBlur();
+			if (typeof onBlur === 'function') {
+				onBlur();
+			}
 		});
 
 		setTimeout(() => {


### PR DESCRIPTION
**PR Type** `BugFix`

**Description** Cypress tests failed due to (onBlur function)`undefined` called as a function.

**Test suite affected** 👉  `stored-query-test.spec.js`

**Related PR** https://github.com/appbaseio-confidential/arc-dashboard/pull/417

[📔  Notion ](https://www.notion.so/appbase/Fix-failing-cypress-tests-0b2e946181c84e4883084369a809bc02)