### PR TITLE
fix: clear the validation response in case of error

### DIFF
--- a/modules/actions/rules.js
+++ b/modules/actions/rules.js
@@ -51,6 +51,7 @@ export function validateScript(requestBody) {
 export function clearValidatedScriptRule() {
 	return (dispatch) => {
 		dispatch(createAction(AppConstants.APP.SCRIPT_RULES.VALIDATE_SUCCESS, '', null));
+		dispatch(createAction(AppConstants.APP.SCRIPT_RULES.VALIDATE_ERROR, '', null));
 	};
 }
 


### PR DESCRIPTION
**PR Type** 🐞  `Fix`

**Description** 
- The PR fixes a bug by clearing the validation response from the redux store once the ScriptConsole is unmounted. 
- Until this PR the clearing action worked only for the success type of validation call but in case there was an error from the validation response the error persisted.

