### PR TITLE
fix: routing strategy for request logs

### DIFF
--- a/components/analytics/components/RequestLogs/RequestDetails.js
+++ b/components/analytics/components/RequestLogs/RequestDetails.js
@@ -60,6 +60,7 @@ const RequestDetails = ({
 	latency,
 	pipelineMode,
 	context,
+	diffLogs,
 }) => {
 	const [rulesData, setRulesData] = useState([]);
 	const timeDuration = getTimeDuration(processingTime);
@@ -161,7 +162,7 @@ const RequestDetails = ({
 						headers={headers}
 						method={method}
 						requestChanges={requestChanges}
-						shouldDecode={!pipelineMode}
+						shouldDecode={diffLogs === false ? false : !pipelineMode}
 					/>
 					{pipelineMode && (
 						<Card
@@ -241,6 +242,7 @@ const RequestDetails = ({
 							url={url}
 							method={method}
 							responseChanges={responseChanges}
+							shouldDecode={diffLogs === false}
 						/>
 					</TabPane>
 				)}
@@ -257,6 +259,7 @@ RequestDetails.defaultProps = {
 	pipelineMode: false,
 	response: {},
 	context: {},
+	diffLogs: true,
 };
 RequestDetails.propTypes = {
 	time: PropTypes.string.isRequired,
@@ -279,6 +282,7 @@ RequestDetails.propTypes = {
 	latency: PropTypes.number,
 	pipelineMode: PropTypes.bool,
 	context: PropTypes.object,
+	diffLogs: PropTypes.bool,
 };
 
 const mapStateToProps = (state) => ({

--- a/components/analytics/components/RequestLogs/ResponseDiff.js
+++ b/components/analytics/components/RequestLogs/ResponseDiff.js
@@ -20,7 +20,7 @@ const popoverContent = css`
 
 const overflow = { whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' };
 
-const ResponseDiff = ({ responseBody, response, responseChanges, method, url }) => {
+const ResponseDiff = ({ responseBody, response, responseChanges, method, url, shouldDecode }) => {
 	const inverseOp = (currentOp) => {
 		switch (currentOp) {
 			case DiffMatchPatch.DIFF_DELETE:
@@ -154,7 +154,9 @@ const ResponseDiff = ({ responseBody, response, responseChanges, method, url }) 
 			{(responseChanges ?? [])
 				.filter((i) => i.stage !== 'searchrelevancy')
 				.map((responseChange) => {
-					const value = decodeResponseChange(responseChange.body, responseBody);
+					const value = shouldDecode
+						? decodeResponseChange(responseChange.body, responseBody)
+						: responseChange.body;
 
 					return (
 						<Card
@@ -212,6 +214,7 @@ ResponseDiff.defaultProps = {
 	method: '',
 	url: '',
 	response: {},
+	shouldDecode: true,
 };
 ResponseDiff.propTypes = {
 	responseChanges: PropTypes.array,
@@ -219,5 +222,6 @@ ResponseDiff.propTypes = {
 	method: PropTypes.string,
 	response: PropTypes.object,
 	url: PropTypes.string,
+	shouldDecode: PropTypes.bool,
 };
 export default ResponseDiff;

--- a/components/analytics/components/RequestLogs/index.js
+++ b/components/analytics/components/RequestLogs/index.js
@@ -150,30 +150,28 @@ class RequestLogs extends React.Component {
 	};
 
 	redirectTo = (tab) => {
-		const { changeUrlOnTabChange, appName, onTabChange } = this.props;
+		const { changeUrlOnTabChange, appName, onTabChange, history } = this.props;
 		if (changeUrlOnTabChange) {
 			if (onTabChange) {
 				onTabChange(tab);
 			} else {
-				window.history.pushState(
-					null,
-					null,
-					`${window.location.origin}/app/${appName}/analytics/request-logs/${tab}`,
-				);
+				history.push(`app/${appName}/analytics/request-logs/${tab}`);
 			}
 		}
 	};
 
 	handleLogClick = (record) => {
 		try {
-			const { pipelineLogsMode, appName } = this.props;
+			const { pipelineLogsMode, appName, history } = this.props;
 
 			if (pipelineLogsMode) {
 				window.location.href = `logs/${record.id}`;
 			} else {
-				window.location.href = appName
-					? `/app/${appName}/request-logs/${record.id}`
-					: `request-logs/${String(record.id)}`;
+				history.push(
+					appName
+						? `app/${appName}/request-logs/${record.id}`
+						: `request-logs/${String(record.id)}`,
+				);
 			}
 		} catch (e) {
 			console.log('Error', e);
@@ -426,6 +424,7 @@ RequestLogs.defaultProps = {
 	hideRefreshButton: false,
 	pipelineLogsMode: false,
 	pipelineId: '',
+	history: null,
 };
 RequestLogs.propTypes = {
 	tab: PropTypes.string,
@@ -444,6 +443,7 @@ RequestLogs.propTypes = {
 	endDate: PropTypes.string,
 	pipelineLogsMode: PropTypes.bool,
 	pipelineId: PropTypes.string,
+	history: PropTypes.object,
 };
 
 const mapStateToProps = (state) => ({


### PR DESCRIPTION
**PR Type** `fix`

**Description** The PR fixes using the history of the object from React-router to navigate to a logs page and enhances the decision to diff the logs on FE based on the `diffLogs` flag received in response.

[Notion ](https://www.notion.so/reactivesearch/Changes-for-logs-in-dashboard-df9cb41399974d629de9bf00ee359ef2)

supports https://github.com/appbaseio-confidential/arc-dashboard/pull/669