### PR TITLE
fix: read mappings from any available object

### DIFF
--- a/utils/mappings.js
+++ b/utils/mappings.js
@@ -40,13 +40,15 @@ export function getMappings(appName, credentials, url = getURL(), endpointSuffix
 			.then((data) => {
 				let mappings = {};
 				if (appName) {
-					const types = Object.keys(data[appName].mappings).filter(
+					const mappingsObject =
+						data[appName]?.mappings ?? Object.values(data)[0].mappings;
+					const types = Object.keys(mappingsObject).filter(
 						(type) => !REMOVED_KEYS.includes(type),
 					);
 					types.forEach((type) => {
 						mappings = {
 							...mappings,
-							[type]: data[appName].mappings[type],
+							[type]: mappingsObject[type],
 						};
 					});
 				} else {


### PR DESCRIPTION
**PR Type** `fix` 

**Description** The PR fixes an issue with mappings access for aliased/  re-indexed indices.

[📔 Notion](https://www.notion.so/reactivesearch/Mapping-bug-in-dashboard-5f9a7a0fd1e844eab47ad0d108a027ab)

https://www.loom.com/share/252a9634f795456686cabfacc07e4296
